### PR TITLE
Add 5AC and 6AC files

### DIFF
--- a/0 - All Cassettes.tas
+++ b/0 - All Cassettes.tas
@@ -1,4 +1,4 @@
-FileTime: 25:22.758(89574)
+FileTime: 25:22.707(89571)
 #Start from Begin
 
 Read,StartFullGameFile
@@ -44,75 +44,7 @@ Read,4A,lvl_b-00
 
 Read,LoadA
 
-Read,5HC,Start,lvl_b-17 (0)
-
-#lvl_b-17
-   3,R,D
-   1,R,J
-   1,R
-  11,R,D,X
-   2,R,J,G
-  10,R
-   3,R,J
-   5,R
-  40
-
-#lvl_b-22
-  14,R,D,X
-   1,L,J
-   6,L,U,X
-   3,R,J
-   7,R
-  15,R,D,X
-  15,D,C
-   2
-   6,R,X
-  44,R,C
-  36,G
-   1
-   2,J
-   5,R,Z
-   4,R,J,G
-   6,R
-   9,R,J
-   4
-  15,R,D,X
-  15,D,C
-  10,L,X
-   6,R,J
-   1,R
-  15,R,X
-  10,R,C
-   9,R,J
-   7,R
-  15,U,Z
-   1,L,J,G
-   1,R,J
-   1,L,J
-   1,R
-   6,L
-   4,Z
-   1,L,J
-   6,L
-   2,L,D,J
-   4,L
-  14,L,X
-   1,L,J
-  15,D,C
-  15,D,X
-  14,L,Z
-   1,R,J
-  13,R,Z
-   1,L,J
-   1,R
-  14,L,D,X
-   1,L,J
-   3,L,K,G
-  15,L,D,X
-   1,L
-   8,L,J
- 257
-   1,J
+Read,5AC,Start,Return
 
 Read,LoadBFromA
 
@@ -120,7 +52,7 @@ Read,5B,Start
 
 Read,LoadAFromB
 
-Read,6HC,Start,Return
+Read,6AC,Start,Return
 
 Read,LoadBFromA
 

--- a/0 - All Red Berries.tas
+++ b/0 - All Red Berries.tas
@@ -1,4 +1,4 @@
-FileTime: 35:33.687(125511)
+FileTime: 35:33.636(125508)
 #Start from Begin
 
 Read,StartFullGameFile
@@ -83,7 +83,7 @@ Read,5S,Depths
 
 Read,LoadA
 
-Read,6HC,Start,Return
+Read,6AC,Start,Return
 
 Read,LoadBFromA
 

--- a/0 - Any%.tas
+++ b/0 - Any%.tas
@@ -23,75 +23,7 @@ Read,4A,Start
 
 Read,LoadANoCollects
 
-Read,5HC,Start,lvl_b-17 (0)
-
-#lvl_b-17
-   3,R,D
-   1,R,J
-   1,R
-  11,R,D,X
-   2,R,J,G
-  10,R
-   3,R,J
-   5,R
-  40
-
-#lvl_b-22
-  14,R,D,X
-   1,L,J
-   6,L,U,X
-   3,R,J
-   7,R
-  15,R,D,X
-  15,D,C
-   2
-   6,R,X
-  44,R,C
-  36,G
-   1
-   2,J
-   5,R,Z
-   4,R,J,G
-   6,R
-   9,R,J
-   4
-  15,R,D,X
-  15,D,C
-  10,L,X
-   6,R,J
-   1,R
-  15,R,X
-  10,R,C
-   9,R,J
-   7,R
-  15,U,Z
-   1,L,J,G
-   1,R,J
-   1,L,J
-   1,R
-   6,L
-   4,Z
-   1,L,J
-   6,L
-   2,L,D,J
-   4,L
-  14,L,X
-   1,L,J
-  15,D,C
-  15,D,X
-  14,L,Z
-   1,R,J
-  13,R,Z
-   1,L,J
-   1,R
-  14,L,D,X
-   1,L,J
-   3,L,K,G
-  15,L,D,X
-   1,L
-   8,L,J
- 257
-   1,J
+Read,5AC,Start,Return
 
 Read,LoadBFromA
 
@@ -99,65 +31,7 @@ Read,5B,Start
 
 Read,LoadAFromB
 
-Read,6HC,Start,lvl_04 (0)
-
-#lvl_04
-   4
-   4,J,G
-   8,R,J
-  14,L,U,X
-   6,L,J,G
-   7,L
-   4,L,J
-   4,L,K,G
-   9,K
-  14,L,U,X
-   1,L,J,G
-   9,L
-  15,U,Z
-   1,J,G
-   7,L
-  10,L,Z
-   5,L,J
-  15,L,X
-   1,L,J,G
-  31,D
-  12,R
-   8,U,X
-  13,L
-  24
-  21,R,G
-  10,D,G
-   1,G
-   5,R,X
-   1,R,J,G
-  23,R,D
-  12,R,Z
-   1,L,J
-   1,L,K
-   1,L,J
-   1,L,K
-   1,L,J
-   1,L,K
-   1,L,J
-   7,L,U,Z
-   1,R
-   3,O
-   1,J,G
-   1,K
-   4,J,G
-  43
-
-#lvl_04e
-   5,J,G
-  16,L,D,X
-   3,L,D,J
-   4,L,K,G
-   5,L
-   4,L,J
-  11,L,U,X
- 257
-   1,J
+Read,6AC,Start,Return
 
 Read,LoadBFromA
 

--- a/0 - Bny%.tas
+++ b/0 - Bny%.tas
@@ -1,4 +1,4 @@
-FileTime: 24:59.281(88193)
+FileTime: 24:59.230(88190)
 #Start from Begin
 
 Read,StartFullGameFile
@@ -91,75 +91,7 @@ Read,4B,Start
 
 Read,LoadAFromB
 
-Read,5HC,Start,lvl_b-17 (0)
-
-#lvl_b-17
-   3,R,D
-   1,R,J
-   1,R
-  11,R,D,X
-   2,R,J,G
-  10,R
-   3,R,J
-   5,R
-  40
-
-#lvl_b-22
-  14,R,D,X
-   1,L,J
-   6,L,U,X
-   3,R,J
-   7,R
-  15,R,D,X
-  15,D,C
-   2
-   6,R,X
-  44,R,C
-  36,G
-   1
-   2,J
-   5,R,Z
-   4,R,J,G
-   6,R
-   9,R,J
-   4
-  15,R,D,X
-  15,D,C
-  10,L,X
-   6,R,J
-   1,R
-  15,R,X
-  10,R,C
-   9,R,J
-   7,R
-  15,U,Z
-   1,L,J,G
-   1,R,J
-   1,L,J
-   1,R
-   6,L
-   4,Z
-   1,L,J
-   6,L
-   2,L,D,J
-   4,L
-  14,L,X
-   1,L,J
-  15,D,C
-  15,D,X
-  14,L,Z
-   1,R,J
-  13,R,Z
-   1,L,J
-   1,R
-  14,L,D,X
-   1,L,J
-   3,L,K,G
-  15,L,D,X
-   1,L
-   8,L,J
- 257
-   1,J
+Read,5AC,Start,Return
 
 Read,LoadBFromA
 
@@ -167,7 +99,7 @@ Read,5B,Start
 
 Read,LoadAFromB
 
-Read,6HC,Start,Return
+Read,6AC,Start,Return
 
 Read,LoadBFromA
 

--- a/0 - True Ending.tas
+++ b/0 - True Ending.tas
@@ -1,4 +1,4 @@
-FileTime: 25:44.365(90845)
+FileTime: 25:44.314(90842)
 #Start from Begin
 
 Read,StartFullGameFile
@@ -27,75 +27,7 @@ Read,4HC,lvl_b-00
 
 Read,LoadA
 
-Read,5HC,Start,lvl_b-17 (0)
-
-#lvl_b-17
-   3,R,D
-   1,R,J
-   1,R
-  11,R,D,X
-   2,R,J,G
-  10,R
-   3,R,J
-   5,R
-  40
-
-#lvl_b-22
-  14,R,D,X
-   1,L,J
-   6,L,U,X
-   3,R,J
-   7,R
-  15,R,D,X
-  15,D,C
-   2
-   6,R,X
-  44,R,C
-  36,G
-   1
-   2,J
-   5,R,Z
-   4,R,J,G
-   6,R
-   9,R,J
-   4
-  15,R,D,X
-  15,D,C
-  10,L,X
-   6,R,J
-   1,R
-  15,R,X
-  10,R,C
-   9,R,J
-   7,R
-  15,U,Z
-   1,L,J,G
-   1,R,J
-   1,L,J
-   1,R
-   6,L
-   4,Z
-   1,L,J
-   6,L
-   2,L,D,J
-   4,L
-  14,L,X
-   1,L,J
-  15,D,C
-  15,D,X
-  14,L,Z
-   1,R,J
-  13,R,Z
-   1,L,J
-   1,R
-  14,L,D,X
-   1,L,J
-   3,L,K,G
-  15,L,D,X
-   1,L
-   8,L,J
- 257
-   1,J
+Read,5AC,Start,Return
 
 Read,LoadBFromA
 
@@ -103,7 +35,7 @@ Read,5B,Start
 
 Read,LoadAFromB
 
-Read,6HC,Start,Return
+Read,6AC,Start,Return
 
 Read,LoadBFromA
 

--- a/5AC.tas
+++ b/5AC.tas
@@ -1,0 +1,69 @@
+console load 5
+   1
+
+#Start
+Read,5HC,Start,lvl_b-22
+
+#lvl_b-22
+  14,R,D,X
+   1,L,J
+   6,L,U,X
+   3,R,J
+   7,R
+  15,R,D,X
+  15,D,C
+   2
+   6,R,X
+  44,R,C
+  36,G
+   1
+   2,J
+   5,R,Z
+   4,R,J,G
+   6,R
+   9,R,J
+   4
+  15,R,D,X
+  15,D,C
+  10,L,X
+   6,R,J
+   1,R
+  15,R,X
+  10,R,C
+   9,R,J
+   7,R
+  15,U,Z
+   1,L,J,G
+   1,R,J
+   1,L,J
+   1,R
+   6,L
+   4,Z
+   1,L,J
+   6,L
+   2,L,D,J
+   4,L
+  14,L,X
+   1,L,J
+  15,D,C
+  15,D,X
+  14,L,Z
+   1,R,J
+  13,R,Z
+   1,L,J
+   1,R
+  14,L,D,X
+   1,L,J
+   3,L,K,G
+  15,L,D,X
+   1,L
+   8,L,J
+ 257
+   1,J
+# Return
+  62
+   1,S
+   1,U,J
+   1,O
+  31
+FileTime: 1:01.795(3635)

--- a/6AC.tas
+++ b/6AC.tas
@@ -1,0 +1,23 @@
+console load 6
+   1
+
+#Start
+Read,6HC,Start,lvl_04e
+
+#lvl_04e
+   5,J,G
+  16,L,D,X
+   3,L,D,J
+   4,L,K,G
+   5,L
+   4,L,J
+  11,L,U,X
+ 257
+   1,J
+# Return
+  62
+   1,S
+   1,U,J
+   1,O
+  31
+FileTime: 0:55.199(3247)


### PR DESCRIPTION
The categories that return to map after the 5A and/or 6A cassettes now read from new 5AC and 6AC files instead of containing the rtm specific inputs directly.